### PR TITLE
Datasource Query timeout Configuration (#107)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,3 +29,13 @@ options:
       host or a bare A record, this may be omitted.
     type: string
     default: ""
+  datasource_query_timeout:
+    description: |
+      The default timeout for querying a Grafana datasource. Each datasource can
+      also configure its own preferred timeout value through relation data. If the
+      value configured through relation data is larger than datasource_query_timeout
+      then that value is left unchanged. The value of this configuration option must
+      be a positive integer representing the maximum number of seconds Grafana will
+      wait for a datasource to respond to a query.
+    type: int
+    default: 300

--- a/src/charm.py
+++ b/src/charm.py
@@ -651,6 +651,15 @@ class GrafanaCharm(CharmBase):
             }
             if source_info.get("extra_fields", None):
                 source["jsonData"] = source_info.get("extra_fields")
+
+            # set timeout for querying this data source
+            timeout = source.get("jsonData", {}).get("timeout", 0)
+            configured_timeout = self.model.config.get("datasource_query_timeout")
+            if timeout < configured_timeout:
+                json_data = source.get("jsonData", {})
+                json_data.update({"timeout": configured_timeout})
+                source["jsonData"] = json_data
+
             datasources_dict["datasources"].append(source)  # type: ignore[attr-defined]
 
         # Also get a list of all the sources which have previously been purged and add them


### PR DESCRIPTION
* Allow configurable datasource query timeouts

This commit adds a configuration parameter to the Grafana charm
that allows setting a minimum default timeout for querrying
data sources. This is necessary because some data sources such
as Loki can take long time to return query responses. If the
Grafana query timeout (which defaults to 30s) is not set suitably
this may lead to 5xx HTTP errors.

* Added unit test datasource timeout config

This commit adds unit tests for the datasource query timeout
configuration. The unit tests check
- that configuration value overrides timeout value set in relation
  data if the configuration value is larger.
- that configuration value is overridden by relation data timeout
  value if the latter is larger.

## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
